### PR TITLE
add the support for Jetson Orin devices whose compute capability is 87

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ def get_generator_flag():
 
 
 def get_compute_capabilities(
-    compute_capabilities={75, 80, 86, 89, 90}
+    compute_capabilities={75, 80, 86, 87, 89, 90}
 ):
     capability_flags = []
 


### PR DESCRIPTION
The NVidia's Jetson Orin devices ( Jetson AGX Orin, Jetson Orin NX, Jetson Orin Nano) have the supported GPUs, but whose compute capability is 87, which not included in setup.py.

I have added it in setup.py, and I have tested, it seems work well on my Jetson AGX Orin 64GB.