### PR TITLE
Upgrade to support PyTorch 2.3.X

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -91,7 +91,7 @@ jobs:
           # Install torch
           $cudaVersion = $env:CUDA_VERSION.Replace('.', '')
           $cudaVersionPytorch = $cudaVersion.Substring(0, $cudaVersion.Length - 1)
-          $pytorchVersion = "torch==2.2.1"
+          $pytorchVersion = "torch==2.3.1"
           python -m pip install --upgrade --no-cache-dir $pytorchVersion+cu$cudaVersionPytorch --index-url https://download.pytorch.org/whl/cu$cudaVersionPytorch
           python -m pip install build setuptools wheel ninja
 

--- a/scripts/download_wheels.sh
+++ b/scripts/download_wheels.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Set variables
-AWQ_KERNELS_VERSION="0.0.6"
+AWQ_KERNELS_VERSION="0.0.7"
 RELEASE_URL="https://api.github.com/repos/casper-hansen/AutoAWQ_kernels/releases/tags/v${AWQ_KERNELS_VERSION}"
 
 # Create a directory to download the wheels

--- a/setup.py
+++ b/setup.py
@@ -118,7 +118,7 @@ def get_extra_compile_args(arch_flags, generator_flags):
         include_arch = os.getenv("INCLUDE_ARCH", "1") == "1"
         # Relaxed args on Windows
         if include_arch:
-            extra_compile_args = {"nvcc": arch_flags}
+            extra_compile_args = {"nvcc": ["-allow-unsupported-compiler"] + arch_flags}
 
     elif CUDA_VERSION:
         extra_compile_args = {

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from torch.utils.cpp_extension import BuildExtension, CUDAExtension
 
 os.environ["CC"] = "g++"
 os.environ["CXX"] = "g++"
-AUTOAWQ_KERNELS_VERSION = "0.0.6"
+AUTOAWQ_KERNELS_VERSION = "0.0.7"
 PYPI_BUILD = os.getenv("PYPI_BUILD", "0") == "1"
 CUDA_VERSION = os.getenv("CUDA_VERSION", None) or torch.version.cuda
 ROCM_VERSION = os.environ.get("ROCM_VERSION", None) or torch.version.hip


### PR DESCRIPTION
As discussed in https://github.com/casper-hansen/AutoAWQ/issues/523, the current version of AutoAWQ_kernels is built against PyTorch 2.2.X. This PR proposes a new release built against the current (2.3.X) version of PyTorch.