### PR TITLE
fix: bump torch to allow higher versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ common_setup_kwargs = {
 }
 
 requirements = [
-    "torch==2.3.1",
+    "torch>=2.3.1",
 ]
 
 


### PR DESCRIPTION
This ensures that we can use awq with the latest versions of torch.